### PR TITLE
Implement C++ MCP sandtimer server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  windows-build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Run tests
+        run: ctest -C Release --output-on-failure
+        working-directory: build
+
+      - name: Package
+        run: cmake --build build --config Release --target package
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-sandtimer-windows
+          path: build/mcp-sandtimer-*.zip
+
+      - name: Publish release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/mcp-sandtimer-*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,26 +10,31 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4 # 拉取仓库代码
 
       - name: Configure CMake
         run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+        # CMake 配置项目，生成 VS2022 x64 的构建文件，输出到 build 目录
 
       - name: Build
         run: cmake --build build --config Release
+        # 构建 Release 配置，生成 mcp-sandtimer.exe
 
       - name: Run tests
         run: ctest -C Release --output-on-failure
         working-directory: build
+        # 运行 CTest 测试套件，任何失败会显示详细输出
 
       - name: Package
         run: cmake --build build --config Release --target package
+        # 执行 CPack 打包命令，生成 ZIP 包 (mcp-sandtimer-版本号-windows-x86_64.zip)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: mcp-sandtimer-windows
           path: build/mcp-sandtimer-*.zip
+        # 将打好的 ZIP 包作为 workflow artifact 上传，方便在 Actions 界面下载
 
       - name: Publish release asset
         uses: softprops/action-gh-release@v2
@@ -37,3 +42,4 @@ jobs:
           files: build/mcp-sandtimer-*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # 把 ZIP 包作为 Release 资产上传到对应 tag 的 GitHub Release 页面

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Build artifacts
+/build/
+/build-*/
+/out/
+/dist/
+/.vs/
+CMakeFiles/
+CMakeCache.txt
+cmake-build-*/
+*.user
+*.log
+*.exe
+*.pdb
+*.obj
+*.dll
+*.lib
+*.exp
+*.ilk
+*.sln
+*.vcxproj*
+*.ninja
+*.ninja_deps
+*.ninja_log
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /out/
 /dist/
 /.vs/
+/.vscode/
 CMakeFiles/
 CMakeCache.txt
 cmake-build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,88 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(mcp-sandtimer VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(BUILD_TESTING "Build tests" ON)
+
+configure_file(
+    include/mcp_sandtimer/Version.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/generated/mcp_sandtimer/Version.h
+    @ONLY
+)
+
+add_library(mcp_sandtimer_lib STATIC
+    src/MCPSandTimerServer.cpp
+    src/TimerClient.cpp
+    src/Json.cpp
+    src/ToolDefinition.cpp
+)
+
+add_library(mcp_sandtimer::lib ALIAS mcp_sandtimer_lib)
+
+set_target_properties(mcp_sandtimer_lib PROPERTIES
+    OUTPUT_NAME mcp_sandtimer
+)
+
+target_include_directories(mcp_sandtimer_lib
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>
+        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:include/mcp_sandtimer>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_sources(mcp_sandtimer_lib
+    PUBLIC
+        FILE_SET HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_BINARY_DIR}/generated
+        FILES
+            include/mcp_sandtimer/MCPSandTimerServer.h
+            include/mcp_sandtimer/TimerClient.h
+            include/mcp_sandtimer/Json.h
+            include/mcp_sandtimer/ToolDefinition.h
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/mcp_sandtimer/Version.h
+)
+
+if (WIN32)
+    target_link_libraries(mcp_sandtimer_lib PRIVATE ws2_32)
+endif()
+
+add_executable(mcp-sandtimer src/main.cpp)
+
+target_link_libraries(mcp-sandtimer PRIVATE mcp_sandtimer_lib)
+
+include(GNUInstallDirs)
+
+install(TARGETS mcp-sandtimer mcp_sandtimer_lib
+    EXPORT mcp_sandtimerTargets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(EXPORT mcp_sandtimerTargets
+    FILE mcp_sandtimerTargets.cmake
+    NAMESPACE mcp_sandtimer::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mcp_sandtimer
+)
+
+set(CPACK_GENERATOR "ZIP")
+set(CPACK_PACKAGE_NAME "mcp-sandtimer")
+set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+set(CPACK_SYSTEM_NAME "windows-x86_64")
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_SYSTEM_NAME}")
+include(CPack)
+
+if (BUILD_TESTING)
+    include(CTest)
+    add_executable(tool_definition_test tests/tool_definition_test.cpp)
+    target_link_libraries(tool_definition_test PRIVATE mcp_sandtimer_lib)
+    add_test(NAME ToolDefinitions COMMAND tool_definition_test)
+endif()

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 MCP Sandtimer Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# MCP Sandtimer Server (C++)
+
+This repository provides a C++ implementation of a Model Context Protocol (MCP) server that exposes the [sandtimer](sandtimer) desktop countdown utility to ChatGPT or any MCP-compatible client. The server receives JSON-RPC requests over STDIN/STDOUT, translates them into TCP commands, and forwards them to the sandtimer process listening on `127.0.0.1:61420`.
+
+## Features
+
+- Implements the MCP JSON-RPC handshake (`initialize`, `tools/list`, `tools/call`, etc.).
+- Provides three tools:
+  - `start_timer(label: string, time: number)`
+  - `reset_timer(label: string)`
+  - `cancel_timer(label: string)`
+- Forwards commands to sandtimer as JSON payloads over TCP, e.g. `{ "cmd": "start", "label": "demo", "time": 60 }`.
+- Lightweight JSON parser/serializer with no external runtime dependencies.
+- CMake-based build that targets Windows and other desktop platforms.
+- GitHub Actions workflow that packages a standalone Windows executable on tagged releases.
+
+## Build Instructions
+
+The project requires a C++17-capable compiler and CMake 3.20+. On Linux/macOS:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+On Windows (PowerShell or Developer Command Prompt):
+
+```powershell
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+cmake --build build --config Release
+```
+
+The resulting executable is located at `build/mcp-sandtimer` (or `build/Release/mcp-sandtimer.exe` on Windows).
+
+### Running the server
+
+Start the sandtimer desktop application so it listens on `127.0.0.1:61420`, then launch the MCP server:
+
+```bash
+./build/mcp-sandtimer --host 127.0.0.1 --port 61420
+```
+
+The server communicates with the MCP client over STDIN/STDOUT. Use `--help` to see available options, including `--list-tools` for quickly inspecting the tool descriptions.
+
+### Tests
+
+Run the lightweight test suite via CTest:
+
+```bash
+cmake --build build --target test
+```
+
+or directly:
+
+```bash
+ctest --test-dir build
+```
+
+## Packaging & Releases
+
+Tagging the repository with `v*` (e.g. `v1.0.0`) automatically triggers the GitHub Actions workflow defined in `.github/workflows/release.yml`. The workflow:
+
+1. Configures and builds the project on `windows-latest` (x64).
+2. Executes the CTest suite in Release mode.
+3. Invokes CPack to generate a ZIP archive containing `mcp-sandtimer.exe`.
+4. Uploads the archive both as a build artifact and as a release asset attached to the tag.
+
+The packaged executable bundles all dependencies required to communicate with sandtimer; no additional runtime (Python, Node.js, etc.) is necessary on the target machine.
+
+## Command-Line Reference
+
+| Option | Description |
+| --- | --- |
+| `--host <hostname>` | Override the sandtimer TCP host (default `127.0.0.1`). |
+| `--port <port>` | Override the sandtimer TCP port (default `61420`). |
+| `--timeout <seconds>` | Socket timeout in seconds (default `5`). |
+| `--list-tools` | Print the MCP tool definitions as JSON and exit. |
+| `--version` | Show version information and exit. |
+| `-h`, `--help` | Display usage help. |
+
+## License
+
+This project is released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/include/mcp_sandtimer/Json.h
+++ b/include/mcp_sandtimer/Json.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstddef>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace mcp_sandtimer::json {
+
+class ParseError : public std::runtime_error {
+public:
+    explicit ParseError(const std::string& message);
+};
+
+class Value {
+public:
+    enum class Type { Null, Boolean, Number, String, Object, Array };
+    using Object = std::map<std::string, Value>;
+    using Array = std::vector<Value>;
+
+    Value();
+    Value(std::nullptr_t);
+    Value(bool value);
+    Value(int value);
+    Value(double value);
+    Value(const char* value);
+    Value(const std::string& value);
+    Value(const Object& value);
+    Value(Object&& value);
+    Value(const Array& value);
+    Value(Array&& value);
+
+    Value(const Value& other);
+    Value(Value&& other) noexcept;
+    Value& operator=(const Value& other);
+    Value& operator=(Value&& other) noexcept;
+    ~Value();
+
+    Type type() const noexcept { return type_; }
+
+    bool is_null() const noexcept { return type_ == Type::Null; }
+    bool is_boolean() const noexcept { return type_ == Type::Boolean; }
+    bool is_number() const noexcept { return type_ == Type::Number; }
+    bool is_string() const noexcept { return type_ == Type::String; }
+    bool is_object() const noexcept { return type_ == Type::Object; }
+    bool is_array() const noexcept { return type_ == Type::Array; }
+
+    bool as_bool() const;
+    double as_number() const;
+    const std::string& as_string() const;
+    const Object& as_object() const;
+    Object& as_object();
+    const Array& as_array() const;
+    Array& as_array();
+
+    std::string dump() const;
+
+    static Value parse(const std::string& text);
+    static Value parse(const char* data, std::size_t size);
+
+private:
+    Type type_{Type::Null};
+    bool bool_value_{false};
+    double number_value_{0.0};
+    std::string string_value_;
+    std::unique_ptr<Object> object_value_;
+    std::unique_ptr<Array> array_value_;
+
+    void copy_from(const Value& other);
+    void move_from(Value&& other) noexcept;
+    void reset();
+    void dump_to(std::string& out) const;
+};
+
+Value make_object(std::initializer_list<std::pair<const std::string, Value>> items);
+Value make_array(std::initializer_list<Value> items);
+
+}  // namespace mcp_sandtimer::json

--- a/include/mcp_sandtimer/Json.h
+++ b/include/mcp_sandtimer/Json.h
@@ -9,15 +9,18 @@
 #include <utility>
 #include <vector>
 
+// 一个简单的JSON数据表示和解析，不支持复杂JSON特性
 namespace mcp_sandtimer::json {
 
 class ParseError : public std::runtime_error {
 public:
     explicit ParseError(const std::string& message);
 };
+// JSON 解析错误时抛出的异常类型，继承自 std::runtime_error
 
 class Value {
 public:
+    // 值类型
     enum class Type { Null, Boolean, Number, String, Object, Array };
     using Object = std::map<std::string, Value>;
     using Array = std::vector<Value>;

--- a/include/mcp_sandtimer/MCPSandTimerServer.h
+++ b/include/mcp_sandtimer/MCPSandTimerServer.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <iostream>
+#include <istream>
+#include <optional>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "mcp_sandtimer/Json.h"
+#include "mcp_sandtimer/TimerClient.h"
+#include "mcp_sandtimer/ToolDefinition.h"
+
+namespace mcp_sandtimer {
+
+class JSONRPCError : public std::runtime_error {
+public:
+    JSONRPCError(int code, std::string message, std::optional<json::Value> data = std::nullopt);
+
+    int code() const noexcept { return code_; }
+    const std::string& message() const noexcept { return message_; }
+    bool has_data() const noexcept { return data_.has_value(); }
+    const json::Value& data() const { return data_.value(); }
+
+private:
+    int code_;
+    std::string message_;
+    std::optional<json::Value> data_;
+};
+
+class MCPSandTimerServer {
+public:
+    MCPSandTimerServer(TimerClient client, std::istream& input = std::cin, std::ostream& output = std::cout);
+
+    void Serve();
+
+    static const std::vector<ToolDefinition>& ToolDefinitions();
+
+private:
+    TimerClient timer_client_;
+    std::istream& input_;
+    std::ostream& output_;
+    bool shutdown_requested_ = false;
+    bool initialized_ = false;
+
+    std::optional<json::Value> ReadMessage();
+    void Dispatch(const json::Value& message);
+    void HandleNotification(const std::string& method, const json::Value& params);
+    json::Value HandleRequest(const std::string& method, const json::Value& params);
+    json::Value HandleInitialize(const json::Value& params);
+    json::Value HandleToolCall(const json::Value& params);
+    std::string HandleStart(const json::Value& arguments);
+    std::string HandleReset(const json::Value& arguments);
+    std::string HandleCancel(const json::Value& arguments);
+    std::string ExtractLabel(const json::Value& arguments);
+    void Send(const json::Value& payload);
+    void SendResponse(const json::Value& id, const json::Value& result);
+    void SendError(const json::Value& id, const JSONRPCError& error);
+};
+
+}  // namespace mcp_sandtimer

--- a/include/mcp_sandtimer/TimerClient.h
+++ b/include/mcp_sandtimer/TimerClient.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include "mcp_sandtimer/Json.h"
+
+namespace mcp_sandtimer {
+
+class TimerClientError : public std::runtime_error {
+public:
+    explicit TimerClientError(const std::string& message);
+};
+
+class TimerClient {
+public:
+    using milliseconds = std::chrono::milliseconds;
+
+    TimerClient();
+    TimerClient(std::string host, std::uint16_t port, milliseconds timeout = milliseconds{5000});
+
+    const std::string& host() const noexcept { return host_; }
+    std::uint16_t port() const noexcept { return port_; }
+    milliseconds timeout() const noexcept { return timeout_; }
+
+    void set_host(std::string host) { host_ = std::move(host); }
+    void set_port(std::uint16_t port) noexcept { port_ = port; }
+    void set_timeout(milliseconds timeout) noexcept { timeout_ = timeout; }
+
+    void start_timer(const std::string& label, int seconds) const;
+    void reset_timer(const std::string& label) const;
+    void cancel_timer(const std::string& label) const;
+
+private:
+    std::string host_;
+    std::uint16_t port_;
+    milliseconds timeout_;
+
+    void send_payload(const json::Value& payload) const;
+};
+
+}  // namespace mcp_sandtimer

--- a/include/mcp_sandtimer/TimerClient.h
+++ b/include/mcp_sandtimer/TimerClient.h
@@ -16,7 +16,7 @@ public:
 
 class TimerClient {
 public:
-    using milliseconds = std::chrono::milliseconds;
+    using milliseconds = std::chrono::milliseconds; // 超时单位
 
     TimerClient();
     TimerClient(std::string host, std::uint16_t port, milliseconds timeout = milliseconds{5000});
@@ -37,7 +37,7 @@ private:
     std::string host_;
     std::uint16_t port_;
     milliseconds timeout_;
-
+    // JSON序列化后发到 sandtimer 监听的 TCP 端口
     void send_payload(const json::Value& payload) const;
 };
 

--- a/include/mcp_sandtimer/ToolDefinition.h
+++ b/include/mcp_sandtimer/ToolDefinition.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "mcp_sandtimer/Json.h"
+
+namespace mcp_sandtimer {
+
+struct ToolDefinition {
+    std::string name;
+    std::string description;
+    json::Value input_schema;
+
+    json::Value ToJson() const;
+};
+
+const std::vector<ToolDefinition>& GetToolDefinitions();
+
+}  // namespace mcp_sandtimer

--- a/include/mcp_sandtimer/ToolDefinition.h
+++ b/include/mcp_sandtimer/ToolDefinition.h
@@ -5,6 +5,7 @@
 
 #include "mcp_sandtimer/Json.h"
 
+// 定义 MCP 协议所需的工具元信息结构及其 JSON 序列化接口
 namespace mcp_sandtimer {
 
 struct ToolDefinition {

--- a/include/mcp_sandtimer/Version.h.in
+++ b/include/mcp_sandtimer/Version.h.in
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace mcp_sandtimer {
+inline constexpr const char* kVersion = "@PROJECT_VERSION@";
+}

--- a/src/Json.cpp
+++ b/src/Json.cpp
@@ -1,0 +1,603 @@
+#include "mcp_sandtimer/Json.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <cstdint>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string_view>
+#include <utility>
+
+namespace mcp_sandtimer::json {
+
+namespace {
+
+class Parser {
+public:
+    Parser(const char* data, std::size_t size) : data_(data), size_(size) {}
+
+    Value parse() {
+        skip_whitespace();
+        if (pos_ >= size_) {
+            throw ParseError("Unexpected end of input");
+        }
+        Value result = parse_value();
+        skip_whitespace();
+        if (pos_ != size_) {
+            throw ParseError("Unexpected trailing data in JSON payload");
+        }
+        return result;
+    }
+
+private:
+    const char* data_;
+    std::size_t size_;
+    std::size_t pos_ = 0;
+
+    void skip_whitespace() {
+        while (pos_ < size_) {
+            unsigned char ch = static_cast<unsigned char>(data_[pos_]);
+            if (ch == ' ' || ch == '\n' || ch == '\r' || ch == '\t') {
+                ++pos_;
+            } else {
+                break;
+            }
+        }
+    }
+
+    bool consume(char expected) {
+        if (pos_ < size_ && data_[pos_] == expected) {
+            ++pos_;
+            return true;
+        }
+        return false;
+    }
+
+    char peek() const {
+        return pos_ < size_ ? data_[pos_] : '\0';
+    }
+
+    char get() {
+        if (pos_ >= size_) {
+            throw ParseError("Unexpected end of input");
+        }
+        return data_[pos_++];
+    }
+
+    Value parse_value() {
+        char ch = peek();
+        switch (ch) {
+            case 'n':
+                return parse_null();
+            case 't':
+                return parse_true();
+            case 'f':
+                return parse_false();
+            case '"':
+                return parse_string();
+            case '{':
+                return parse_object();
+            case '[':
+                return parse_array();
+            default:
+                if (ch == '-' || std::isdigit(static_cast<unsigned char>(ch))) {
+                    return parse_number();
+                }
+                throw ParseError("Invalid JSON value");
+        }
+    }
+
+    Value parse_null() {
+        expect_literal("null");
+        return Value(nullptr);
+    }
+
+    Value parse_true() {
+        expect_literal("true");
+        return Value(true);
+    }
+
+    Value parse_false() {
+        expect_literal("false");
+        return Value(false);
+    }
+
+    void expect_literal(std::string_view literal) {
+        if (size_ - pos_ < literal.size()) {
+            throw ParseError("Unexpected end of input");
+        }
+        if (std::string_view(data_ + pos_, literal.size()) != literal) {
+            throw ParseError("Unexpected literal in JSON payload");
+        }
+        pos_ += literal.size();
+    }
+
+    Value parse_string() {
+        if (!consume('"')) {
+            throw ParseError("Expected opening quote for string");
+        }
+        std::string result;
+        while (pos_ < size_) {
+            char ch = get();
+            if (ch == '"') {
+                return Value(std::move(result));
+            }
+            if (ch == '\\') {
+                if (pos_ >= size_) {
+                    throw ParseError("Invalid escape sequence");
+                }
+                char escape = get();
+                switch (escape) {
+                    case '"':
+                        result.push_back('"');
+                        break;
+                    case '\\':
+                        result.push_back('\\');
+                        break;
+                    case '/':
+                        result.push_back('/');
+                        break;
+                    case 'b':
+                        result.push_back('\b');
+                        break;
+                    case 'f':
+                        result.push_back('\f');
+                        break;
+                    case 'n':
+                        result.push_back('\n');
+                        break;
+                    case 'r':
+                        result.push_back('\r');
+                        break;
+                    case 't':
+                        result.push_back('\t');
+                        break;
+                    case 'u': {
+                        uint32_t codepoint = parse_hex4();
+                        if (codepoint >= 0xD800 && codepoint <= 0xDBFF) {
+                            // High surrogate; expect another \uXXXX sequence.
+                            if (!(consume('\\') && consume('u'))) {
+                                throw ParseError("Invalid Unicode surrogate pair");
+                            }
+                            uint32_t low = parse_hex4();
+                            if (low < 0xDC00 || low > 0xDFFF) {
+                                throw ParseError("Invalid Unicode surrogate pair");
+                            }
+                            codepoint = 0x10000 + ((codepoint - 0xD800) << 10) + (low - 0xDC00);
+                        }
+                        append_utf8(codepoint, result);
+                        break;
+                    }
+                    default:
+                        throw ParseError("Invalid escape sequence");
+                }
+            } else {
+                result.push_back(ch);
+            }
+        }
+        throw ParseError("Unterminated string literal");
+    }
+
+    uint32_t parse_hex4() {
+        if (pos_ + 4 > size_) {
+            throw ParseError("Invalid Unicode escape");
+        }
+        uint32_t value = 0;
+        for (int i = 0; i < 4; ++i) {
+            char ch = data_[pos_++];
+            value <<= 4;
+            if (ch >= '0' && ch <= '9') {
+                value |= static_cast<uint32_t>(ch - '0');
+            } else if (ch >= 'a' && ch <= 'f') {
+                value |= static_cast<uint32_t>(10 + (ch - 'a'));
+            } else if (ch >= 'A' && ch <= 'F') {
+                value |= static_cast<uint32_t>(10 + (ch - 'A'));
+            } else {
+                throw ParseError("Invalid character in Unicode escape");
+            }
+        }
+        return value;
+    }
+
+    void append_utf8(uint32_t codepoint, std::string& out) {
+        if (codepoint <= 0x7F) {
+            out.push_back(static_cast<char>(codepoint));
+        } else if (codepoint <= 0x7FF) {
+            out.push_back(static_cast<char>(0xC0 | ((codepoint >> 6) & 0x1F)));
+            out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+        } else if (codepoint <= 0xFFFF) {
+            out.push_back(static_cast<char>(0xE0 | ((codepoint >> 12) & 0x0F)));
+            out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+            out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+        } else {
+            out.push_back(static_cast<char>(0xF0 | ((codepoint >> 18) & 0x07)));
+            out.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+            out.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+            out.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+        }
+    }
+
+    Value parse_number() {
+        std::size_t start = pos_;
+        if (consume('-')) {
+            if (pos_ >= size_ || !std::isdigit(static_cast<unsigned char>(peek()))) {
+                throw ParseError("Invalid number format");
+            }
+        }
+        if (consume('0')) {
+            // no leading zeros allowed; nothing else to do here
+        } else {
+            if (pos_ >= size_ || !std::isdigit(static_cast<unsigned char>(peek()))) {
+                throw ParseError("Invalid number format");
+            }
+            while (pos_ < size_ && std::isdigit(static_cast<unsigned char>(peek()))) {
+                ++pos_;
+            }
+        }
+
+        if (consume('.')) {
+            if (pos_ >= size_ || !std::isdigit(static_cast<unsigned char>(peek()))) {
+                throw ParseError("Invalid number format");
+            }
+            while (pos_ < size_ && std::isdigit(static_cast<unsigned char>(peek()))) {
+                ++pos_;
+            }
+        }
+
+        if (peek() == 'e' || peek() == 'E') {
+            ++pos_;
+            if (peek() == '+' || peek() == '-') {
+                ++pos_;
+            }
+            if (pos_ >= size_ || !std::isdigit(static_cast<unsigned char>(peek()))) {
+                throw ParseError("Invalid number format");
+            }
+            while (pos_ < size_ && std::isdigit(static_cast<unsigned char>(peek()))) {
+                ++pos_;
+            }
+        }
+
+        std::string_view slice(data_ + start, pos_ - start);
+        std::string buffer(slice);
+        char* end_ptr = nullptr;
+        double value = std::strtod(buffer.c_str(), &end_ptr);
+        if (end_ptr == buffer.c_str()) {
+            throw ParseError("Failed to parse numeric value");
+        }
+        return Value(value);
+    }
+
+    Value parse_array() {
+        if (!consume('[')) {
+            throw ParseError("Expected '[' to begin array");
+        }
+        Value::Array elements;
+        skip_whitespace();
+        if (consume(']')) {
+            return Value(std::move(elements));
+        }
+        while (true) {
+            skip_whitespace();
+            elements.emplace_back(parse_value());
+            skip_whitespace();
+            if (consume(']')) {
+                break;
+            }
+            if (!consume(',')) {
+                throw ParseError("Expected comma in array");
+            }
+        }
+        return Value(std::move(elements));
+    }
+
+    Value parse_object() {
+        if (!consume('{')) {
+            throw ParseError("Expected '{' to begin object");
+        }
+        Value::Object members;
+        skip_whitespace();
+        if (consume('}')) {
+            return Value(std::move(members));
+        }
+        while (true) {
+            skip_whitespace();
+            if (peek() != '"') {
+                throw ParseError("Expected string key in object");
+            }
+            Value key = parse_string();
+            std::string key_text = key.as_string();
+            skip_whitespace();
+            if (!consume(':')) {
+                throw ParseError("Expected ':' after object key");
+            }
+            skip_whitespace();
+            Value value = parse_value();
+            members.emplace(std::move(key_text), std::move(value));
+            skip_whitespace();
+            if (consume('}')) {
+                break;
+            }
+            if (!consume(',')) {
+                throw ParseError("Expected comma in object");
+            }
+        }
+        return Value(std::move(members));
+    }
+};
+
+void dump_string(const std::string& input, std::string& out) {
+    out.push_back('"');
+    for (char ch : input) {
+        switch (ch) {
+            case '"':
+                out += "\\\"";
+                break;
+            case '\\':
+                out += "\\\\";
+                break;
+            case '\b':
+                out += "\\b";
+                break;
+            case '\f':
+                out += "\\f";
+                break;
+            case '\n':
+                out += "\\n";
+                break;
+            case '\r':
+                out += "\\r";
+                break;
+            case '\t':
+                out += "\\t";
+                break;
+            default: {
+                unsigned char uc = static_cast<unsigned char>(ch);
+                if (uc < 0x20) {
+                    static const char* hex = "0123456789ABCDEF";
+                    out += "\\u00";
+                    out.push_back(hex[(uc >> 4) & 0x0F]);
+                    out.push_back(hex[uc & 0x0F]);
+                } else {
+                    out.push_back(ch);
+                }
+                break;
+            }
+        }
+    }
+    out.push_back('"');
+}
+
+std::string number_to_string(double value) {
+    if (!std::isfinite(value)) {
+        throw ParseError("Cannot serialise non-finite number");
+    }
+    std::ostringstream oss;
+    oss.setf(std::ios::fmtflags(0), std::ios::floatfield);
+    oss << std::setprecision(15) << value;
+    std::string result = oss.str();
+    // Remove trailing zeros for integers.
+    if (result.find('.') != std::string::npos) {
+        while (!result.empty() && result.back() == '0') {
+            result.pop_back();
+        }
+        if (!result.empty() && result.back() == '.') {
+            result.pop_back();
+        }
+        if (result.empty()) {
+            result = "0";
+        }
+    }
+    return result;
+}
+
+}  // namespace
+
+ParseError::ParseError(const std::string& message) : std::runtime_error(message) {}
+
+Value::Value() = default;
+Value::Value(std::nullptr_t) : type_(Type::Null) {}
+Value::Value(bool value) : type_(Type::Boolean), bool_value_(value) {}
+Value::Value(int value) : type_(Type::Number), number_value_(static_cast<double>(value)) {}
+Value::Value(double value) : type_(Type::Number), number_value_(value) {}
+Value::Value(const char* value) : type_(Type::String), string_value_(value ? value : "") {}
+Value::Value(const std::string& value) : type_(Type::String), string_value_(value) {}
+Value::Value(const Object& value)
+    : type_(Type::Object), object_value_(std::make_unique<Object>(value)) {}
+Value::Value(Object&& value)
+    : type_(Type::Object), object_value_(std::make_unique<Object>(std::move(value))) {}
+Value::Value(const Array& value)
+    : type_(Type::Array), array_value_(std::make_unique<Array>(value)) {}
+Value::Value(Array&& value)
+    : type_(Type::Array), array_value_(std::make_unique<Array>(std::move(value))) {}
+
+Value::Value(const Value& other) { copy_from(other); }
+Value::Value(Value&& other) noexcept { move_from(std::move(other)); }
+
+Value& Value::operator=(const Value& other) {
+    if (this != &other) {
+        reset();
+        copy_from(other);
+    }
+    return *this;
+}
+
+Value& Value::operator=(Value&& other) noexcept {
+    if (this != &other) {
+        reset();
+        move_from(std::move(other));
+    }
+    return *this;
+}
+
+Value::~Value() = default;
+
+void Value::copy_from(const Value& other) {
+    type_ = other.type_;
+    bool_value_ = other.bool_value_;
+    number_value_ = other.number_value_;
+    string_value_ = other.string_value_;
+    if (other.object_value_) {
+        object_value_ = std::make_unique<Object>(*other.object_value_);
+    }
+    if (other.array_value_) {
+        array_value_ = std::make_unique<Array>(*other.array_value_);
+    }
+}
+
+void Value::move_from(Value&& other) noexcept {
+    type_ = other.type_;
+    bool_value_ = other.bool_value_;
+    number_value_ = other.number_value_;
+    string_value_ = std::move(other.string_value_);
+    object_value_ = std::move(other.object_value_);
+    array_value_ = std::move(other.array_value_);
+    other.type_ = Type::Null;
+    other.bool_value_ = false;
+    other.number_value_ = 0.0;
+    other.string_value_.clear();
+}
+
+void Value::reset() {
+    type_ = Type::Null;
+    bool_value_ = false;
+    number_value_ = 0.0;
+    string_value_.clear();
+    object_value_.reset();
+    array_value_.reset();
+}
+
+bool Value::as_bool() const {
+    if (!is_boolean()) {
+        throw ParseError("JSON value is not a boolean");
+    }
+    return bool_value_;
+}
+
+double Value::as_number() const {
+    if (!is_number()) {
+        throw ParseError("JSON value is not a number");
+    }
+    return number_value_;
+}
+
+const std::string& Value::as_string() const {
+    if (!is_string()) {
+        throw ParseError("JSON value is not a string");
+    }
+    return string_value_;
+}
+
+const Value::Object& Value::as_object() const {
+    if (!is_object() || !object_value_) {
+        throw ParseError("JSON value is not an object");
+    }
+    return *object_value_;
+}
+
+Value::Object& Value::as_object() {
+    if (!is_object() || !object_value_) {
+        throw ParseError("JSON value is not an object");
+    }
+    return *object_value_;
+}
+
+const Value::Array& Value::as_array() const {
+    if (!is_array() || !array_value_) {
+        throw ParseError("JSON value is not an array");
+    }
+    return *array_value_;
+}
+
+Value::Array& Value::as_array() {
+    if (!is_array() || !array_value_) {
+        throw ParseError("JSON value is not an array");
+    }
+    return *array_value_;
+}
+
+std::string Value::dump() const {
+    std::string result;
+    dump_to(result);
+    return result;
+}
+
+void Value::dump_to(std::string& out) const {
+    switch (type_) {
+        case Type::Null:
+            out += "null";
+            break;
+        case Type::Boolean:
+            out += bool_value_ ? "true" : "false";
+            break;
+        case Type::Number:
+            out += number_to_string(number_value_);
+            break;
+        case Type::String:
+            dump_string(string_value_, out);
+            break;
+        case Type::Array: {
+            out.push_back('[');
+            if (array_value_) {
+                bool first = true;
+                for (const auto& element : *array_value_) {
+                    if (!first) {
+                        out.push_back(',');
+                    }
+                    first = false;
+                    element.dump_to(out);
+                }
+            }
+            out.push_back(']');
+            break;
+        }
+        case Type::Object: {
+            out.push_back('{');
+            if (object_value_) {
+                bool first = true;
+                for (const auto& [key, value] : *object_value_) {
+                    if (!first) {
+                        out.push_back(',');
+                    }
+                    first = false;
+                    dump_string(key, out);
+                    out.push_back(':');
+                    value.dump_to(out);
+                }
+            }
+            out.push_back('}');
+            break;
+        }
+    }
+}
+
+Value Value::parse(const std::string& text) {
+    return parse(text.data(), text.size());
+}
+
+Value Value::parse(const char* data, std::size_t size) {
+    Parser parser(data, size);
+    return parser.parse();
+}
+
+Value make_object(std::initializer_list<std::pair<const std::string, Value>> items) {
+    Value::Object object;
+    for (auto& item : items) {
+        object.emplace(item.first, item.second);
+    }
+    return Value(std::move(object));
+}
+
+Value make_array(std::initializer_list<Value> items) {
+    Value::Array array;
+    array.reserve(items.size());
+    for (const auto& item : items) {
+        array.push_back(item);
+    }
+    return Value(std::move(array));
+}
+
+}  // namespace mcp_sandtimer::json

--- a/src/MCPSandTimerServer.cpp
+++ b/src/MCPSandTimerServer.cpp
@@ -1,0 +1,342 @@
+#include "mcp_sandtimer/MCPSandTimerServer.h"
+
+#include <algorithm>
+#include <cctype>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "mcp_sandtimer/ToolDefinition.h"
+#include "mcp_sandtimer/Version.h"
+
+namespace mcp_sandtimer {
+namespace {
+constexpr const char* kProtocolVersion = "0.1";
+
+std::string Trim(const std::string& value) {
+    std::size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
+        ++start;
+    }
+    std::size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+        --end;
+    }
+    return value.substr(start, end - start);
+}
+
+std::string ToLower(std::string text) {
+    std::transform(text.begin(), text.end(), text.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return text;
+}
+
+}  // namespace
+
+JSONRPCError::JSONRPCError(int code, std::string message, std::optional<json::Value> data)
+    : std::runtime_error(message), code_(code), message_(std::move(message)), data_(std::move(data)) {}
+
+MCPSandTimerServer::MCPSandTimerServer(TimerClient client, std::istream& input, std::ostream& output)
+    : timer_client_(std::move(client)), input_(input), output_(output) {}
+
+void MCPSandTimerServer::Serve() {
+    while (!shutdown_requested_) {
+        std::optional<json::Value> message;
+        try {
+            message = ReadMessage();
+        } catch (const JSONRPCError& error) {
+            std::cerr << "Failed to read JSON-RPC message: " << error.what() << std::endl;
+            continue;
+        }
+
+        if (!message.has_value()) {
+            break;
+        }
+
+        try {
+            Dispatch(*message);
+        } catch (const JSONRPCError& error) {
+            try {
+                const auto& object = message->as_object();
+                auto id_iter = object.find("id");
+                if (id_iter != object.end()) {
+                    SendError(id_iter->second, error);
+                }
+            } catch (const json::ParseError&) {
+                std::cerr << "Unable to send error response: invalid JSON message." << std::endl;
+            }
+        } catch (const std::exception& ex) {
+            try {
+                const auto& object = message->as_object();
+                auto id_iter = object.find("id");
+                if (id_iter != object.end()) {
+                    JSONRPCError internal_error(
+                        -32603,
+                        "Internal error",
+                        json::make_object({{"message", json::Value("An unexpected error occurred.")}}));
+                    SendError(id_iter->second, internal_error);
+                }
+            } catch (const std::exception&) {
+                std::cerr << "Failed to send internal error response: " << ex.what() << std::endl;
+            }
+        }
+    }
+}
+
+const std::vector<ToolDefinition>& MCPSandTimerServer::ToolDefinitions() {
+    return GetToolDefinitions();
+}
+
+std::optional<json::Value> MCPSandTimerServer::ReadMessage() {
+    std::string line;
+    std::size_t content_length = 0;
+    bool saw_header = false;
+
+    while (true) {
+        if (!std::getline(input_, line)) {
+            if (!saw_header && input_.eof()) {
+                return std::nullopt;
+            }
+            throw JSONRPCError(-32700, "Unexpected end of stream while reading headers");
+        }
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        if (line.empty()) {
+            break;
+        }
+        saw_header = true;
+        auto colon = line.find(':');
+        if (colon == std::string::npos) {
+            throw JSONRPCError(-32700, "Invalid header line", json::make_object({{"header", json::Value(line.c_str())}}));
+        }
+        std::string key = ToLower(line.substr(0, colon));
+        std::string value = Trim(line.substr(colon + 1));
+        if (key == "content-length") {
+            try {
+                content_length = static_cast<std::size_t>(std::stoul(value));
+            } catch (const std::exception&) {
+                throw JSONRPCError(-32600, "Invalid Content-Length header");
+            }
+        }
+    }
+
+    if (!saw_header && input_.eof()) {
+        return std::nullopt;
+    }
+
+    if (content_length == 0) {
+        throw JSONRPCError(-32600, "Missing Content-Length header");
+    }
+
+    std::string payload(content_length, '\0');
+    input_.read(payload.data(), static_cast<std::streamsize>(content_length));
+    if (static_cast<std::size_t>(input_.gcount()) != content_length) {
+        throw JSONRPCError(-32700, "Unexpected end of stream while reading payload");
+    }
+
+    try {
+        return json::Value::parse(payload);
+    } catch (const json::ParseError& error) {
+        throw JSONRPCError(-32700, "Parse error", json::make_object({{"message", json::Value(error.what())}}));
+    }
+}
+
+void MCPSandTimerServer::Dispatch(const json::Value& message) {
+    const auto& object = message.as_object();
+    auto method_iter = object.find("method");
+    if (method_iter == object.end() || !method_iter->second.is_string()) {
+        throw JSONRPCError(-32600, "Invalid Request", json::make_object({{"message", json::Value("Missing method.")}}));
+    }
+    const std::string& method = method_iter->second.as_string();
+
+    auto params_iter = object.find("params");
+    json::Value params = params_iter != object.end() ? params_iter->second : json::Value(json::Value::Object{});
+
+    auto id_iter = object.find("id");
+    if (id_iter == object.end()) {
+        HandleNotification(method, params);
+        return;
+    }
+
+    json::Value result = HandleRequest(method, params);
+    SendResponse(id_iter->second, result);
+}
+
+void MCPSandTimerServer::HandleNotification(const std::string& method, const json::Value& params) {
+    (void)params;
+    if (method == "notifications/initialized") {
+        return;
+    }
+    if (method == "notifications/cancelled") {
+        std::cerr << "Received cancellation notification" << std::endl;
+        return;
+    }
+    std::cerr << "Ignoring notification: " << method << std::endl;
+}
+
+json::Value MCPSandTimerServer::HandleRequest(const std::string& method, const json::Value& params) {
+    if (method == "initialize") {
+        return HandleInitialize(params);
+    }
+    if (method == "shutdown") {
+        shutdown_requested_ = true;
+        return json::Value(nullptr);
+    }
+    if (method == "tools/list") {
+        json::Value::Array tools_array;
+        for (const auto& tool : GetToolDefinitions()) {
+            tools_array.push_back(tool.ToJson());
+        }
+        return json::make_object({{"tools", json::Value(std::move(tools_array))}});
+    }
+    if (method == "tools/call") {
+        return HandleToolCall(params);
+    }
+    if (method == "ping") {
+        return json::make_object({{"message", json::Value("pong")}});
+    }
+    throw JSONRPCError(-32601, "Method not found", json::make_object({{"method", json::Value(method.c_str())}}));
+}
+
+json::Value MCPSandTimerServer::HandleInitialize(const json::Value& params) {
+    (void)params;
+    initialized_ = true;
+    json::Value server_info = json::make_object({
+        {"name", json::Value("mcp-sandtimer")},
+        {"version", json::Value(kVersion)}
+    });
+    json::Value capabilities = json::make_object({
+        {"tools", json::make_object({{"listChanged", json::Value(false)}})}
+    });
+    return json::make_object({
+        {"protocolVersion", json::Value(kProtocolVersion)},
+        {"serverInfo", server_info},
+        {"capabilities", capabilities}
+    });
+}
+
+json::Value MCPSandTimerServer::HandleToolCall(const json::Value& params) {
+    const auto& object = params.as_object();
+    auto name_iter = object.find("name");
+    if (name_iter == object.end() || !name_iter->second.is_string()) {
+        throw JSONRPCError(-32602, "Invalid params", json::make_object({{"message", json::Value("Tool name must be provided as a string.")}}));
+    }
+    std::string name = name_iter->second.as_string();
+
+    json::Value arguments;
+    auto args_iter = object.find("arguments");
+    if (args_iter != object.end()) {
+        if (!args_iter->second.is_object()) {
+            throw JSONRPCError(-32602, "Invalid params", json::make_object({{"message", json::Value("Tool arguments must be provided as an object.")}}));
+        }
+        arguments = args_iter->second;
+    } else {
+        arguments = json::Value(json::Value::Object{});
+    }
+
+    std::string text;
+    if (name == "start_timer") {
+        text = HandleStart(arguments);
+    } else if (name == "reset_timer") {
+        text = HandleReset(arguments);
+    } else if (name == "cancel_timer") {
+        text = HandleCancel(arguments);
+    } else {
+        throw JSONRPCError(-32601, "Tool not found", json::make_object({{"name", json::Value(name.c_str())}}));
+    }
+
+    json::Value::Array content;
+    content.push_back(json::make_object({{"type", json::Value("text")}, {"text", json::Value(text.c_str())}}));
+    return json::make_object({{"content", json::Value(std::move(content))}});
+}
+
+std::string MCPSandTimerServer::HandleStart(const json::Value& arguments) {
+    std::string label = ExtractLabel(arguments);
+    const auto& object = arguments.as_object();
+    auto time_iter = object.find("time");
+    if (time_iter == object.end() || !time_iter->second.is_number()) {
+        throw JSONRPCError(-32602, "Invalid params", json::make_object({{"message", json::Value("The 'time' property must be a positive number.")}}));
+    }
+    double seconds_value = time_iter->second.as_number();
+    if (seconds_value <= 0) {
+        throw JSONRPCError(-32602, "Invalid params", json::make_object({{"message", json::Value("Timer length must be greater than zero.")}}));
+    }
+    int seconds = static_cast<int>(seconds_value);
+    try {
+        timer_client_.start_timer(label, seconds);
+    } catch (const TimerClientError& error) {
+        throw JSONRPCError(-32001, "Failed to reach sandtimer", json::make_object({{"message", json::Value(error.what())}}));
+    }
+    std::ostringstream oss;
+    oss << "Started timer '" << label << "' for " << seconds << " seconds.";
+    return oss.str();
+}
+
+std::string MCPSandTimerServer::HandleReset(const json::Value& arguments) {
+    std::string label = ExtractLabel(arguments);
+    try {
+        timer_client_.reset_timer(label);
+    } catch (const TimerClientError& error) {
+        throw JSONRPCError(-32001, "Failed to reach sandtimer", json::make_object({{"message", json::Value(error.what())}}));
+    }
+    return "Reset timer '" + label + "'.";
+}
+
+std::string MCPSandTimerServer::HandleCancel(const json::Value& arguments) {
+    std::string label = ExtractLabel(arguments);
+    try {
+        timer_client_.cancel_timer(label);
+    } catch (const TimerClientError& error) {
+        throw JSONRPCError(-32001, "Failed to reach sandtimer", json::make_object({{"message", json::Value(error.what())}}));
+    }
+    return "Cancelled timer '" + label + "'.";
+}
+
+std::string MCPSandTimerServer::ExtractLabel(const json::Value& arguments) {
+    const auto& object = arguments.as_object();
+    auto iter = object.find("label");
+    if (iter == object.end() || !iter->second.is_string()) {
+        throw JSONRPCError(-32602, "Invalid params", json::make_object({{"message", json::Value("A non-empty string label is required.")}}));
+    }
+    std::string label = Trim(iter->second.as_string());
+    if (label.empty()) {
+        throw JSONRPCError(-32602, "Invalid params", json::make_object({{"message", json::Value("A non-empty string label is required.")}}));
+    }
+    return label;
+}
+
+void MCPSandTimerServer::Send(const json::Value& payload) {
+    const std::string encoded = payload.dump();
+    output_ << "Content-Length: " << encoded.size() << "\r\n\r\n" << encoded;
+    output_.flush();
+}
+
+void MCPSandTimerServer::SendResponse(const json::Value& id, const json::Value& result) {
+    json::Value response = json::make_object({
+        {"jsonrpc", json::Value("2.0")},
+        {"id", id},
+        {"result", result}
+    });
+    Send(response);
+}
+
+void MCPSandTimerServer::SendError(const json::Value& id, const JSONRPCError& error) {
+    json::Value error_object = json::make_object({
+        {"code", json::Value(error.code())},
+        {"message", json::Value(error.message().c_str())}
+    });
+    if (error.has_data()) {
+        error_object.as_object()["data"] = error.data();
+    }
+    json::Value response = json::make_object({
+        {"jsonrpc", json::Value("2.0")},
+        {"id", id},
+        {"error", error_object}
+    });
+    Send(response);
+}
+
+}  // namespace mcp_sandtimer

--- a/src/TimerClient.cpp
+++ b/src/TimerClient.cpp
@@ -1,0 +1,196 @@
+#include "mcp_sandtimer/TimerClient.h"
+
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#endif
+
+#include "mcp_sandtimer/Json.h"
+
+namespace mcp_sandtimer {
+
+namespace {
+#ifdef _WIN32
+struct WinsockSession {
+    WinsockSession() {
+        WSADATA data{};
+        const int result = WSAStartup(MAKEWORD(2, 2), &data);
+        if (result != 0) {
+            std::ostringstream oss;
+            oss << "WSAStartup failed with error " << result;
+            throw TimerClientError(oss.str());
+        }
+    }
+    ~WinsockSession() { WSACleanup(); }
+};
+using socket_handle = SOCKET;
+constexpr socket_handle kInvalidSocket = INVALID_SOCKET;
+inline void close_socket(socket_handle socket) {
+    if (socket != kInvalidSocket) {
+        closesocket(socket);
+    }
+}
+inline std::string last_error_message(const std::string& prefix) {
+    const int code = WSAGetLastError();
+    std::ostringstream oss;
+    oss << prefix << " (code " << code << ")";
+    return oss.str();
+}
+#else
+using socket_handle = int;
+constexpr socket_handle kInvalidSocket = -1;
+inline void close_socket(socket_handle socket) {
+    if (socket != kInvalidSocket) {
+        close(socket);
+    }
+}
+inline std::string last_error_message(const std::string& prefix) {
+    std::ostringstream oss;
+    oss << prefix << ": " << std::strerror(errno);
+    return oss.str();
+}
+#endif
+}  // namespace
+
+TimerClientError::TimerClientError(const std::string& message) : std::runtime_error(message) {}
+
+TimerClient::TimerClient() : TimerClient("127.0.0.1", 61420) {}
+
+TimerClient::TimerClient(std::string host, std::uint16_t port, milliseconds timeout)
+    : host_(std::move(host)), port_(port), timeout_(timeout) {}
+
+void TimerClient::start_timer(const std::string& label, int seconds) const {
+    json::Value payload = json::make_object({
+        {"cmd", json::Value("start")},
+        {"label", json::Value(label.c_str())},
+        {"time", json::Value(seconds)}
+    });
+    send_payload(payload);
+}
+
+void TimerClient::reset_timer(const std::string& label) const {
+    json::Value payload = json::make_object({
+        {"cmd", json::Value("reset")},
+        {"label", json::Value(label.c_str())}
+    });
+    send_payload(payload);
+}
+
+void TimerClient::cancel_timer(const std::string& label) const {
+    json::Value payload = json::make_object({
+        {"cmd", json::Value("cancel")},
+        {"label", json::Value(label.c_str())}
+    });
+    send_payload(payload);
+}
+
+void TimerClient::send_payload(const json::Value& payload) const {
+    const std::string message = payload.dump();
+
+#ifdef _WIN32
+    WinsockSession session;
+#endif
+
+    struct AddrInfoDeleter {
+        void operator()(addrinfo* ptr) const { if (ptr) { freeaddrinfo(ptr); } }
+    };
+
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    std::unique_ptr<addrinfo, AddrInfoDeleter> info;
+    std::string port_string = std::to_string(port_);
+
+    addrinfo* raw_info = nullptr;
+    int status = getaddrinfo(host_.c_str(), port_string.c_str(), &hints, &raw_info);
+    if (status != 0) {
+#ifdef _WIN32
+        std::ostringstream oss;
+        oss << "getaddrinfo failed with error " << status;
+        throw TimerClientError(oss.str());
+#else
+        throw TimerClientError(std::string("getaddrinfo failed: ") + gai_strerror(status));
+#endif
+    }
+    info.reset(raw_info);
+
+    bool sent = false;
+    std::string error_message;
+
+    for (addrinfo* entry = info.get(); entry != nullptr; entry = entry->ai_next) {
+        socket_handle socket = ::socket(entry->ai_family, entry->ai_socktype, entry->ai_protocol);
+        if (socket == kInvalidSocket) {
+            error_message = last_error_message("Failed to create socket");
+            continue;
+        }
+
+#ifdef _WIN32
+        DWORD timeout_ms = static_cast<DWORD>(timeout_.count());
+        setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+        setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+#else
+        struct timeval tv;
+        tv.tv_sec = static_cast<long>(timeout_.count() / 1000);
+        tv.tv_usec = static_cast<long>((timeout_.count() % 1000) * 1000);
+        setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+        setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+#endif
+
+        if (::connect(socket, entry->ai_addr, static_cast<int>(entry->ai_addrlen)) != 0) {
+            error_message = last_error_message("Failed to connect to sandtimer");
+            close_socket(socket);
+            continue;
+        }
+
+        const char* data = message.data();
+        std::size_t remaining = message.size();
+        while (remaining > 0) {
+            int chunk = ::send(socket, data, static_cast<int>(remaining), 0);
+#ifdef _WIN32
+            if (chunk == SOCKET_ERROR) {
+                error_message = last_error_message("Failed to send payload");
+                break;
+            }
+#else
+            if (chunk < 0) {
+                error_message = last_error_message("Failed to send payload");
+                break;
+            }
+#endif
+            data += chunk;
+            remaining -= static_cast<std::size_t>(chunk);
+        }
+
+        close_socket(socket);
+
+        if (remaining == 0) {
+            sent = true;
+            break;
+        }
+    }
+
+    if (!sent) {
+        if (error_message.empty()) {
+            error_message = "Unable to deliver payload to sandtimer";
+        }
+        throw TimerClientError(error_message);
+    }
+}
+
+}  // namespace mcp_sandtimer

--- a/src/ToolDefinition.cpp
+++ b/src/ToolDefinition.cpp
@@ -4,6 +4,7 @@
 
 namespace mcp_sandtimer {
 
+// 把 ToolDefinition 转为 JSON 格式
 json::Value ToolDefinition::ToJson() const {
     return json::make_object({
         {"name", json::Value(name)},
@@ -12,55 +13,61 @@ json::Value ToolDefinition::ToJson() const {
     });
 }
 
+// 集中定义 MCP 工具列表及其输入参数 JSON Schema
 const std::vector<ToolDefinition>& GetToolDefinitions() {
     static const std::vector<ToolDefinition> kDefinitions = [] {
         using json::Value;
-        using json::make_array;
-        using json::make_object;
 
-        Value start_schema = make_object({
-            {"type", Value("object")},
-            {"properties", make_object({
-                {"label", make_object({
-                    {"type", Value("string")},
-                    {"description", Value("Identifier shown in the sandtimer window.")},
-                    {"minLength", Value(1)}
-                })},
-                {"time", make_object({
-                    {"type", Value("number")},
-                    {"description", Value("Duration for the countdown in seconds.")},
-                    {"minimum", Value(1)}
-                })}
-            })},
-            {"required", make_array({Value("label"), Value("time")})},
-            {"additionalProperties", Value(false)}
-        });
+        // 用 JSON 字符串直接定义 schema
+        Value start_schema = Value::parse(R"json(
+        {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "Identifier shown in the sandtimer window.",
+              "minLength": 1
+            },
+            "time": {
+              "type": "number",
+              "description": "Duration for the countdown in seconds.",
+              "minimum": 1
+            }
+          },
+          "required": ["label", "time"],
+          "additionalProperties": false
+        }
+        )json");
 
-        Value reset_schema = make_object({
-            {"type", Value("object")},
-            {"properties", make_object({
-                {"label", make_object({
-                    {"type", Value("string")},
-                    {"description", Value("Identifier of the timer to reset.")},
-                    {"minLength", Value(1)}
-                })}
-            })},
-            {"required", make_array({Value("label")})},
-            {"additionalProperties", Value(false)}
-        });
+        Value reset_schema = Value::parse(R"json(
+        {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "Identifier of the timer to reset.",
+              "minLength": 1
+            }
+          },
+          "required": ["label"],
+          "additionalProperties": false
+        }
+        )json");
 
-        Value cancel_schema = make_object({
-            {"type", Value("object")},
-            {"properties", make_object({
-                {"label", make_object({
-                    {"type", Value("string")},
-                    {"description", Value("Identifier of the timer to cancel.")},
-                    {"minLength", Value(1)}
-                })}
-            })},
-            {"required", make_array({Value("label")})},
-            {"additionalProperties", Value(false)}
-        });
+        Value cancel_schema = Value::parse(R"json(
+        {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string",
+              "description": "Identifier of the timer to cancel.",
+              "minLength": 1
+            }
+          },
+          "required": ["label"],
+          "additionalProperties": false
+        }
+        )json");
 
         return std::vector<ToolDefinition>{
             ToolDefinition{"start_timer", "Start or restart a sandtimer countdown.", start_schema},

--- a/src/ToolDefinition.cpp
+++ b/src/ToolDefinition.cpp
@@ -1,0 +1,74 @@
+#include "mcp_sandtimer/ToolDefinition.h"
+
+#include <utility>
+
+namespace mcp_sandtimer {
+
+json::Value ToolDefinition::ToJson() const {
+    return json::make_object({
+        {"name", json::Value(name)},
+        {"description", json::Value(description)},
+        {"inputSchema", input_schema}
+    });
+}
+
+const std::vector<ToolDefinition>& GetToolDefinitions() {
+    static const std::vector<ToolDefinition> kDefinitions = [] {
+        using json::Value;
+        using json::make_array;
+        using json::make_object;
+
+        Value start_schema = make_object({
+            {"type", Value("object")},
+            {"properties", make_object({
+                {"label", make_object({
+                    {"type", Value("string")},
+                    {"description", Value("Identifier shown in the sandtimer window.")},
+                    {"minLength", Value(1)}
+                })},
+                {"time", make_object({
+                    {"type", Value("number")},
+                    {"description", Value("Duration for the countdown in seconds.")},
+                    {"minimum", Value(1)}
+                })}
+            })},
+            {"required", make_array({Value("label"), Value("time")})},
+            {"additionalProperties", Value(false)}
+        });
+
+        Value reset_schema = make_object({
+            {"type", Value("object")},
+            {"properties", make_object({
+                {"label", make_object({
+                    {"type", Value("string")},
+                    {"description", Value("Identifier of the timer to reset.")},
+                    {"minLength", Value(1)}
+                })}
+            })},
+            {"required", make_array({Value("label")})},
+            {"additionalProperties", Value(false)}
+        });
+
+        Value cancel_schema = make_object({
+            {"type", Value("object")},
+            {"properties", make_object({
+                {"label", make_object({
+                    {"type", Value("string")},
+                    {"description", Value("Identifier of the timer to cancel.")},
+                    {"minLength", Value(1)}
+                })}
+            })},
+            {"required", make_array({Value("label")})},
+            {"additionalProperties", Value(false)}
+        });
+
+        return std::vector<ToolDefinition>{
+            ToolDefinition{"start_timer", "Start or restart a sandtimer countdown.", start_schema},
+            ToolDefinition{"reset_timer", "Reset an existing sandtimer back to its original duration.", reset_schema},
+            ToolDefinition{"cancel_timer", "Close an active sandtimer window and cancel its countdown.", cancel_schema},
+        };
+    }();
+    return kDefinitions;
+}
+
+}  // namespace mcp_sandtimer

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,122 @@
+#include "mcp_sandtimer/MCPSandTimerServer.h"
+#include "mcp_sandtimer/TimerClient.h"
+#include "mcp_sandtimer/ToolDefinition.h"
+#include "mcp_sandtimer/Version.h"
+#include "mcp_sandtimer/Json.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+struct Options {
+    std::string host = "127.0.0.1";
+    std::uint16_t port = 61420;
+    int timeout_ms = 5000;
+    bool list_tools = false;
+    bool show_version = false;
+    bool show_help = false;
+};
+
+void PrintUsage() {
+    std::cout << "Usage: mcp-sandtimer [options]\n"
+              << "\n"
+              << "Options:\n"
+              << "  --host <hostname>     Address of the sandtimer TCP server (default 127.0.0.1)\n"
+              << "  --port <port>         TCP port exposed by sandtimer (default 61420)\n"
+              << "  --timeout <seconds>   Connection timeout in seconds (default 5)\n"
+              << "  --list-tools          Print the MCP tool descriptions as JSON and exit\n"
+              << "  --version             Print version information and exit\n"
+              << "  -h, --help            Show this message\n";
+}
+
+bool ParseInteger(const std::string& text, long long& output) {
+    char* end = nullptr;
+    long long value = std::strtoll(text.c_str(), &end, 10);
+    if (end == text.c_str() || *end != '\0') {
+        return false;
+    }
+    output = value;
+    return true;
+}
+
+Options ParseOptions(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--host") {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("--host requires an argument");
+            }
+            options.host = argv[++i];
+        } else if (arg == "--port") {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("--port requires an argument");
+            }
+            long long value = 0;
+            if (!ParseInteger(argv[++i], value) || value <= 0 || value > 65535) {
+                throw std::runtime_error("--port expects a positive integer between 1 and 65535");
+            }
+            options.port = static_cast<std::uint16_t>(value);
+        } else if (arg == "--timeout") {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("--timeout requires an argument");
+            }
+            long long value = 0;
+            if (!ParseInteger(argv[++i], value) || value < 0) {
+                throw std::runtime_error("--timeout expects a non-negative integer");
+            }
+            options.timeout_ms = static_cast<int>(value * 1000);
+        } else if (arg == "--list-tools") {
+            options.list_tools = true;
+        } else if (arg == "--version") {
+            options.show_version = true;
+        } else if (arg == "--help" || arg == "-h") {
+            options.show_help = true;
+        } else {
+            throw std::runtime_error("Unrecognised argument: " + arg);
+        }
+    }
+    return options;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        Options options = ParseOptions(argc, argv);
+        using mcp_sandtimer::json::Value;
+
+        if (options.show_help) {
+            PrintUsage();
+            return 0;
+        }
+
+        if (options.show_version) {
+            std::cout << "mcp-sandtimer " << mcp_sandtimer::kVersion << std::endl;
+            return 0;
+        }
+
+        if (options.list_tools) {
+            Value::Array tools_json;
+            for (const auto& tool : mcp_sandtimer::MCPSandTimerServer::ToolDefinitions()) {
+                tools_json.push_back(tool.ToJson());
+            }
+            Value payload = Value(std::move(tools_json));
+            std::cout << payload.dump() << std::endl;
+            return 0;
+        }
+
+        mcp_sandtimer::TimerClient client(options.host, options.port, std::chrono::milliseconds(options.timeout_ms));
+        mcp_sandtimer::MCPSandTimerServer server(std::move(client));
+        server.Serve();
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "mcp-sandtimer: " << ex.what() << std::endl;
+        return 1;
+    }
+}

--- a/tests/tool_definition_test.cpp
+++ b/tests/tool_definition_test.cpp
@@ -1,0 +1,33 @@
+#include "mcp_sandtimer/MCPSandTimerServer.h"
+
+#include <iostream>
+#include <set>
+#include <string>
+
+int main() {
+    const auto& tools = mcp_sandtimer::MCPSandTimerServer::ToolDefinitions();
+    if (tools.size() != 3) {
+        std::cerr << "Expected 3 tools but found " << tools.size() << std::endl;
+        return 1;
+    }
+
+    std::set<std::string> names;
+    for (const auto& tool : tools) {
+        if (tool.name.empty()) {
+            std::cerr << "Tool name must not be empty" << std::endl;
+            return 1;
+        }
+        if (tool.description.empty()) {
+            std::cerr << "Tool description must not be empty" << std::endl;
+            return 1;
+        }
+        names.insert(tool.name);
+    }
+
+    if (names.count("start_timer") == 0 || names.count("reset_timer") == 0 || names.count("cancel_timer") == 0) {
+        std::cerr << "Tool names are incomplete" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace the original Python prototype with a C++17 MCP server that handles JSON-RPC messaging and forwards sandtimer tool calls over TCP【F:src/MCPSandTimerServer.cpp†L1-L340】【F:src/TimerClient.cpp†L1-L194】
- add a lightweight JSON parser, command-line interface, and a unit test that validates the exported MCP tools【F:include/mcp_sandtimer/Json.h†L1-L80】【F:src/main.cpp†L1-L122】【F:tests/tool_definition_test.cpp†L1-L33】
- configure CMake-based builds, documentation, and a Windows release workflow that publishes a ZIP package on tagged pushes【F:CMakeLists.txt†L1-L88】【F:README.md†L1-L83】【F:.github/workflows/release.yml†L1-L39】

## Testing
- `cmake --build build`【d2b2c7†L1-L4】
- `ctest --test-dir build`【c9fc20†L1-L9】
- `cmake --build build --target package`【5e363f†L1-L4】

------
https://chatgpt.com/codex/tasks/task_e_68ce836089b8832fbcd43c8c70b48dac