### PR TITLE
Rename logger level enum constants to avoid Windows macro conflict

### DIFF
--- a/include/mcp_sandtimer/Logger.h
+++ b/include/mcp_sandtimer/Logger.h
@@ -9,9 +9,9 @@ namespace mcp_sandtimer {
 class Logger {
 public:
     enum class Level {
-        DEBUG = 0,
-        INFO = 1,
-        ERROR = 2
+        Debug = 0,
+        Info = 1,
+        Error = 2
     };
 
     static Logger& Instance();
@@ -37,7 +37,7 @@ private:
 
     std::ofstream stream_;
     mutable std::mutex mutex_;
-    Level level_ = Level::INFO;
+    Level level_ = Level::Info;
 };
 
 }  // namespace mcp_sandtimer

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -36,7 +36,7 @@ Logger& Logger::Instance() {
 }
 
 Logger::Logger() : stream_("mcp-sandtimer.log", std::ios::app) {
-    level_ = Level::INFO;
+    level_ = Level::Info;
     const char* env = std::getenv("MCP_SANDTIMER_LOG_LEVEL");
     if (env) {
         level_ = ParseLevelName(env, level_);
@@ -65,15 +65,15 @@ void Logger::SetLevel(const std::string& level_name) {
 }
 
 void Logger::Debug(const std::string& message) {
-    Instance().Log(Level::DEBUG, message);
+    Instance().Log(Level::Debug, message);
 }
 
 void Logger::Info(const std::string& message) {
-    Instance().Log(Level::INFO, message);
+    Instance().Log(Level::Info, message);
 }
 
 void Logger::Error(const std::string& message) {
-    Instance().Log(Level::ERROR, message);
+    Instance().Log(Level::Error, message);
 }
 
 void Logger::Log(Level level, const std::string& message) {
@@ -88,7 +88,7 @@ void Logger::Log(Level level, const std::string& message) {
         stream_ << formatted << std::endl;
         stream_.flush();
     }
-    if (level == Level::ERROR) {
+    if (level == Level::Error) {
         std::cerr << formatted << std::endl;
     }
 }
@@ -99,11 +99,11 @@ bool Logger::ShouldLog(Level level) const {
 
 std::string Logger::LevelToString(Level level) {
     switch (level) {
-        case Level::DEBUG:
+        case Level::Debug:
             return "DEBUG";
-        case Level::INFO:
+        case Level::Info:
             return "INFO";
-        case Level::ERROR:
+        case Level::Error:
             return "ERROR";
     }
     return "INFO";
@@ -117,13 +117,13 @@ Logger::Level Logger::ParseLevelName(const std::string& level_name, Level defaul
     }
 
     if (normalized == "DEBUG") {
-        return Level::DEBUG;
+        return Level::Debug;
     }
     if (normalized == "INFO") {
-        return Level::INFO;
+        return Level::Info;
     }
     if (normalized == "ERROR") {
-        return Level::ERROR;
+        return Level::Error;
     }
     return default_level;
 }


### PR DESCRIPTION
## Summary
- rename the `Logger::Level` enumerators to PascalCase to avoid collisions with Windows macros
- update the logger implementation to use the new names while preserving string conversions

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d1459e1e68832fae798fd67efcaa17